### PR TITLE
Add check for sudo command and use su instead if not available

### DIFF
--- a/library/db2
+++ b/library/db2
@@ -57,6 +57,23 @@ EXAMPLES = '''
 - action: db2 instance=my_instance dbname=my_cool_db command='db2 get db cfg'
 '''
 
+def which(program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
 
 def write_to_output(outputfile, output, output_format=False):
     if outputfile and os.path.exists(outputfile) and not outputfile.startswith('/tmp'):
@@ -77,7 +94,11 @@ def write_to_output(outputfile, output, output_format=False):
 
 
 def instance_command(m, instance, instanceuser, command, outputfile, output_format):
-    command = 'sudo -iu %s %s' % (instanceuser, command)
+    if which('sudo'):
+        command = 'sudo -iu %s %s' % (instanceuser, command)
+    else:
+        command = 'su - %s -c %s' % (instanceuser, command)
+
     rc, out, err = m.run_command(command)
 
     res_args = {
@@ -97,7 +118,12 @@ def database_command(m, instance, instanceuser, dbname, command, outputfile, out
     tmpfilehandle.close()
     os.close(tmpfile[0])
     os.chmod(tmpfile[1], 0755)
-    command = 'sudo -iu %s %s' % (instanceuser, tmpfile[1])
+
+    if which('sudo'):
+        command = 'sudo -iu %s %s' % (instanceuser, tmpfile[1])
+    else:
+        command = 'su - %s -c %s' % (instanceuser, tmpfile[1])
+
     rc, out, err = m.run_command(command)
     os.remove(tmpfile[1])
 


### PR DESCRIPTION
In some environments/different OS's, the use of sudo is either unavailable or removed from use.
I'd like to query the ansible becomes_method to detect this properly but for now, checking that sudo is unavailable and resorting to su is a method which works.
